### PR TITLE
Fix version up error

### DIFF
--- a/show_cls.py
+++ b/show_cls.py
@@ -51,4 +51,4 @@ for i, data in enumerate(testdataloader, 0):
 
     pred_choice = pred.data.max(1)[1]
     correct = pred_choice.eq(target.data).cpu().sum()
-    print('i:%d  loss: %f accuracy: %f' %(i, loss.data[0], correct/float(32)))
+    print('i:%d  loss: %f accuracy: %f' %(i, loss.item(), correct/float(32)))


### PR DESCRIPTION
There is a problem caused by different versions(Pytorch 1), ``data[0]``
So I think it's better to use different functions. ``.item()``

This is also fixed in the original repo. https://github.com/fxia22/pointnet.pytorch/pull/34/commits/f6eeca147ae0cb9588ebb3f3284ea7210cf09110

Thank you.